### PR TITLE
refactor: remove deprecated body parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ This is an example using [express-jsdoc-swagger](https://www.npmjs.com/package/e
 
 ```js
 const express = require('express');
-const bodyParser = require('body-parser');
 const expressJSDocSwagger = require('express-jsdoc-swagger');
 const { init, validateMiddleware, responseValidation } = require('express-oas-validator');
 
@@ -169,8 +168,10 @@ const serverApp = () => new Promise(resolve => {
     init(data);
     resolve(app);
   });
-  app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(bodyParser.json());
+
+  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json());
+
   /**
    * A song
    * @typedef {object} Song

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@commitlint/cli": "^12.0.1",
     "@commitlint/config-conventional": "^12.0.1",
-    "body-parser": "^1.19.0",
     "eslint": "^7.21.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",

--- a/test/fake-server.js
+++ b/test/fake-server.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const bodyParser = require('body-parser');
 const expressJSDocSwagger = require('express-jsdoc-swagger');
 const { init, validateMiddleware, responseValidation } = require('..');
 
@@ -23,8 +22,11 @@ const serverApp = () => new Promise(resolve => {
     init(data);
     resolve(app);
   });
-  app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(bodyParser.json());
+
+  // Add middleware to parse request body
+  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json());
+
   /**
    * A song
    * @typedef {object} Song


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [ ] Feature
 - [X] Test
 - [X] Docs
 - [X] Refactor
 - [X] Build-related changes
 - [ ] Other, please describe:

### Description:

From Express v4.16.0 onwards, [`json`](http://expressjs.com/en/api.html#express.json) and [`urlencoded`](http://expressjs.com/en/api.html#express.urlencoded) middlewares are already bundled into Express, so it's not necessary to install the [`body-parser` dependency](https://github.com/expressjs/body-parser/commit/b7420f8dc5c8b17a277c9e50d72bbaf3086a3900). Thus, the fake server used for testing has been modified to use the default middlewares and `body-parser` has been removed from the dev dependencies list. 

The example in `README` has also been updated by removing references to the deprecated `bodyParser` object, matching the new code in `fake-server.js`.