### PR TITLE
fix: exclude additional options from content type validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5988,9 +5988,9 @@
       }
     },
     "openapi-validator-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-validator-utils/-/openapi-validator-utils-1.1.3.tgz",
-      "integrity": "sha512-nuPUV31lV73IynZO/ka4eSUhv9hy86+eg2+DtS1E+F0sm7DzLmrvhvFuxu7QTqwgFdC4gepAhjbc3uUjdbP2zg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/openapi-validator-utils/-/openapi-validator-utils-1.1.4.tgz",
+      "integrity": "sha512-wdSxlXJcfJWn0huHaUis8oQpF+L/oZqtp8wPsrfgKe7T4IKFXoHeOtDLMn8/VYgu4c7Ehr26bSeYib5WDVhzvA==",
       "requires": {
         "ajv": "^8.2.0",
         "ajv-formats": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tui-jsdoc-template": "^1.2.2"
   },
   "dependencies": {
-    "openapi-validator-utils": "^1.1.3"
+    "openapi-validator-utils": "^1.1.4"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -29,6 +29,14 @@ describe('Body request tests', () => {
       .expect(200)
   ));
 
+  it('should not throw error when content type contains additional options in request body', () => (
+    request
+      .post('/api/v1/songs')
+      .set('Content-Type', 'application/json; charset=utf-8')
+      .send({ title: 'valid title' })
+      .expect(200)
+  ));
+
   it('should throw error when request is not valid', () => (
     request
       .post('/api/v1/songs')

--- a/utils/index.js
+++ b/utils/index.js
@@ -39,7 +39,8 @@ const formatURL = req => {
  * @param {object} req express request object
  */
 const getParameters = req => {
-  const contentType = req.headers['content-type'] || 'application/json';
+  const [contentType] = req.headers['content-type']
+    ? req.headers['content-type'].split(';') : ['application/json'];
   const method = req.method.toLowerCase();
   // eslint-disable-next-line no-underscore-dangle
   const endpoint = formatURL(req);


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [x] Bugfix
 - [ ] Feature
 - [x] Test
 - [ ] Docs
 - [ ] Refactor
 - [x] Build-related changes
 - [ ] Other, please describe:

### Description:

If the content type header included [additional options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#syntax) (such as `charset`), the validation would fail even if the media type matched the one we were expecting. 

An example of the error is presented below:

```
{
  "type":"Error",
  "message":"Method: \"post\" and Endpoint: \"/api/sample\" does not have requestBody with this ContentType: \"application/json;charset=utf-8\"",
  "extra":""
}
```

In this case, our endpoint was expected to receive an request body of type `application/json`. However, the validator was returning an error because the content type included the extra option `charset`, even though the actual content type was still an `application/json`. 

This PR fixes the issue by excluding those additional options from the content type check.

### Task list:

:bug: **Bug fixes**
- [x] Exclude additional options from content type validation.

:heavy_check_mark: **Test**
- [x] Check that validator doesn't return an error if options are provided in content type header.

:whale: **Project configuration**
- [x] Update `openapi-validator-utils` to version 1.1.4.