### PR TITLE
refactor: rename validate methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a basic usage of this package.
 const express = require('express');
 // We recommed to install "body-parser" to validate request body
 const bodyParser = require('body-parser');
-const { init, validateMiddleware, responseValidation } = require('express-oas-validator');
+const { init, validateRequest, validateResponse } = require('express-oas-validator');
 const swaggerDefinition = require('./swaggerDefinition.json');
 
 const app = express();
@@ -36,17 +36,17 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
 // Middleware validator
-app.post('/api/v1/songs', validateMiddleware(), (req, res) => res.send('You save a song!'));
+app.post('/api/v1/songs', validateRequest(), (req, res) => res.send('You save a song!'));
 
 // Middleware validator with custom configuration
-app.get('/api/v1/albums/:id', validateMiddleware({ headers: false }), (req, res) => (
+app.get('/api/v1/albums/:id', validateRequest({ headers: false }), (req, res) => (
   res.json([{
     title: 'abum 1',
   }])
 ));
 
 // Middleware validator with custom configuration
-app.get('/api/v1/authors', validateMiddleware({ body: false, query: false }), (req, res) => (
+app.get('/api/v1/authors', validateRequest({ body: false, query: false }), (req, res) => (
   res.json([{
     title: 'abum 1',
   }])
@@ -55,7 +55,7 @@ app.get('/api/v1/authors', validateMiddleware({ body: false, query: false }), (r
 // Response validator
 app.post('/api/v1/name', (req, res, next) => {
   try {
-    responseValidation('Error string', req, 200);
+    validateResponse('Error string', req, 200);
     return res.send('Hello World!');
   } catch (error) {
     return next(error);
@@ -72,7 +72,7 @@ app.use((err, req, res, next) => {
 
 ### init(openApiDef, options)
 
-This methods initiates the validator so that `validateMiddleware` and `responseValidation` can be used in different files.
+This methods initiates the validator so that `validateRequest` and `validateResponse` can be used in different files.
 
 **Parameters**
 
@@ -88,7 +88,7 @@ init(swaggerDefinition);
 ```
 
 
-## validateMiddleware(endpointConfig)
+## validateRequest(endpointConfig)
 
 
 Express middleware that receives this configuration options and validates each of the options.
@@ -108,21 +108,21 @@ const DEFAULT_CONFIG = {
 
 ```js
 // This one uses the DEFAULT_CONFIG
-app.get('/api/v1/albums/:id', validateMiddleware(), (req, res) => (
+app.get('/api/v1/albums/:id', validateRequest(), (req, res) => (
   res.json([{
     title: 'abum 1',
   }])
 ));
 
 // With custom configuration
-app.get('/api/v1/albums/:id', validateMiddleware({ headers: false }), (req, res) => (
+app.get('/api/v1/albums/:id', validateRequest({ headers: false }), (req, res) => (
   res.json([{
     title: 'abum 1',
   }])
 ));
 ```
 
-## responseValidation(payload, req, status)
+## validateResponse(payload, req, status)
 
 Method to validate response payload based on the docs and the status we want to validate.
 
@@ -138,7 +138,7 @@ Method to validate response payload based on the docs and the status we want to 
 **Example**
 
 ```js
-responseValidation('Error string', req, 200);
+validateResponse('Error string', req, 200);
 ```
 
 ## Example with express-jsdoc-swagger
@@ -148,7 +148,7 @@ This is an example using [express-jsdoc-swagger](https://www.npmjs.com/package/e
 ```js
 const express = require('express');
 const expressJSDocSwagger = require('express-jsdoc-swagger');
-const { init, validateMiddleware, responseValidation } = require('express-oas-validator');
+const { init, validateRequest, validateResponse } = require('express-oas-validator');
 
 const options = {
   info: {
@@ -187,7 +187,7 @@ const serverApp = () => new Promise(resolve => {
    * @param {Song} request.body.required - song info
    * @return {object} 200 - song response
    */
-  app.post('/api/v1/songs', validateMiddleware(), (req, res) => res.send('You save a song!'));
+  app.post('/api/v1/songs', validateRequest(), (req, res) => res.send('You save a song!'));
 
   /**
    * POST /api/v1/name
@@ -196,7 +196,7 @@ const serverApp = () => new Promise(resolve => {
    */
   app.post('/api/v1/name', (req, res, next) => {
     try {
-      responseValidation('Error string', req);
+      validateResponse('Error string', req);
       return res.send('Hello World!');
     } catch (error) {
       return next(error);
@@ -210,7 +210,7 @@ const serverApp = () => new Promise(resolve => {
    * @param {array<string>} license.query - name param description
    * @return {object} 200 - success response - application/json
    */
-  app.get('/api/v1/authors', validateMiddleware({ headers: false }), (req, res) => (
+  app.get('/api/v1/authors', validateRequest({ headers: false }), (req, res) => (
     res.json([{
       title: 'abum 1',
     }])

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const init = (openApiDef, options = {}) => {
  * Endpoint configuration
  * @param {EndpointConfig} endpointConfig middleware validator options
  */
-const validateMiddleware = endpointConfig => (req, res, next) => {
+const validateRequest = endpointConfig => (req, res, next) => {
   const config = getConfig(endpointConfig);
   try {
     const {
@@ -81,7 +81,7 @@ const validateMiddleware = endpointConfig => (req, res, next) => {
  * @param {object} req express request object
  * @param {number} status response status we want to validate
  */
-const responseValidation = (payload, req, status = 200) => {
+const validateResponse = (payload, req, status = 200) => {
   try {
     const {
       contentType,
@@ -96,4 +96,4 @@ const responseValidation = (payload, req, status = 200) => {
   }
 };
 
-module.exports = { init, validateMiddleware, responseValidation };
+module.exports = { init, validateRequest, validateResponse };

--- a/index.js
+++ b/index.js
@@ -11,16 +11,17 @@ const getConfig = require('./utils/config');
 let instance = null;
 
 /**
- * Validator methods
- * @typedef {object} Options
- * @property {function()} errorHandler custom error handler
- * @property {object} ajvConfig Ajv config object
+ * Validator settings
+ * @typedef {object} ValidatorOptions
+ * @property {function} errorHandler - Custom error handler
+ * @property {object} ajvConfig - Ajv config object
  */
 
 /**
  * Init method to instantiate the OpenAPI validator
- * @param {object} openApiDef OpenAPI definition
- * @param {Options} options Options to extend the errorHandler or Ajv configuration
+ * @param {object} openApiDef - OpenAPI definition
+ * @param {ValidatorOptions} [options] - Options to extend the errorHandler or
+ *  Ajv configuration
  */
 const init = (openApiDef, options = {}) => {
   if (instance === null) {
@@ -30,18 +31,22 @@ const init = (openApiDef, options = {}) => {
 };
 
 /**
- * Validator methods
- * @typedef {object} EndpointConfig
- * @property {boolean} body custom error handler
- * @property {boolean} params Ajv config object
- * @property {boolean} headers Ajv config object
- * @property {boolean} query Ajv config object
- * @property {boolean} required Ajv config object
+ * Request validation configuration object
+ * @typedef {object} RequestValidationConfig
+ * @property {boolean} [body] - Indicates if request body will be validated
+ * @property {boolean} [params] - Indicates if path params will be validated
+ * @property {boolean} [headers] - Indicates if request headers will be validated
+ * @property {boolean} [query] - Indicates if query params will be validated
+ * @property {boolean} [required] - Indicates if required fields will be validated
  */
 
 /**
- * Endpoint configuration
- * @param {EndpointConfig} endpointConfig middleware validator options
+ * Validate data on the request complies with the schema specified in the open
+ * API definition object. By default, this validates path params, query params,
+ * headers and request body.
+ *
+ * @param {RequestValidationConfig} [endpointConfig] - Middleware validator
+ *  options, which will allow configuring which elements will be validated
  */
 const validateRequest = endpointConfig => (req, res, next) => {
   const config = getConfig(endpointConfig);
@@ -77,9 +82,9 @@ const validateRequest = endpointConfig => (req, res, next) => {
 
 /**
  * Method to validate response payload
- * @param {*} payload response we want to validate
- * @param {object} req express request object
- * @param {number} status response status we want to validate
+ * @param {*} payload - Response we want to validate
+ * @param {object} req - Express request object
+ * @param {number} [status] - Response status we want to validate
  */
 const validateResponse = (payload, req, status = 200) => {
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-oas-validator",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-oas-validator",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "express openapi middleware validator",
   "main": "index.js",
   "scripts": {

--- a/test/fake-server.js
+++ b/test/fake-server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const expressJSDocSwagger = require('express-jsdoc-swagger');
-const { init, validateMiddleware, responseValidation } = require('..');
+const { init, validateRequest, validateResponse } = require('..');
 
 const options = {
   info: {
@@ -40,20 +40,20 @@ const serverApp = () => new Promise(resolve => {
    * @param {Song} request.body.required - song info
    * @return {object} 200 - song response
    */
-  app.post('/api/v1/songs', validateMiddleware(), (req, res) => res.send('You save a song!'));
+  app.post('/api/v1/songs', validateRequest(), (req, res) => res.send('You save a song!'));
 
   /**
    * PATCH /api/v1/songs
    * @return {object} 200 - song response
    */
-  app.patch('/api/v1/songs', validateMiddleware(), (req, res) => res.send('You save a song!'));
+  app.patch('/api/v1/songs', validateRequest(), (req, res) => res.send('You save a song!'));
 
   /**
    * POST /api/v1/albums
    * @param {array<Song>} request.body.required
    * @return {object} 200 - song response
    */
-  app.post('/api/v1/albums', validateMiddleware({
+  app.post('/api/v1/albums', validateRequest({
     body: false,
     params: false,
     headers: false,
@@ -68,7 +68,7 @@ const serverApp = () => new Promise(resolve => {
    */
   app.post('/api/v1/name', (req, res, next) => {
     try {
-      responseValidation('Error string', req);
+      validateResponse('Error string', req);
       return res.send('Hello World!');
     } catch (error) {
       return next(error);
@@ -82,7 +82,7 @@ const serverApp = () => new Promise(resolve => {
    */
   app.post('/api/v2/name', (req, res, next) => {
     try {
-      responseValidation('Error string', req, 200);
+      validateResponse('Error string', req, 200);
       return res.send('Hello World!');
     } catch (error) {
       return next(error);
@@ -95,7 +95,7 @@ const serverApp = () => new Promise(resolve => {
    * @param {string} id.path.required
    * @return {object} 200 - success response - application/json
    */
-  app.get('/api/v1/albums/:id', validateMiddleware(), (req, res) => (
+  app.get('/api/v1/albums/:id', validateRequest(), (req, res) => (
     res.json([{
       title: 'abum 1',
     }])
@@ -108,7 +108,7 @@ const serverApp = () => new Promise(resolve => {
    * @param {number} songId.path.required
    * @return {object} 200 - success response - application/json
    */
-  app.get('/api/v1/albums/:id/songs/:songId', validateMiddleware(), (req, res) => (
+  app.get('/api/v1/albums/:id/songs/:songId', validateRequest(), (req, res) => (
     res.json([{
       title: 'abum 1',
     }])
@@ -121,7 +121,7 @@ const serverApp = () => new Promise(resolve => {
    * @param {array<string>} license.query - name param description
    * @return {object} 200 - success response - application/json
    */
-  app.get('/api/v1/authors', validateMiddleware(), (req, res) => (
+  app.get('/api/v1/authors', validateRequest(), (req, res) => (
     res.json([{
       title: 'abum 1',
     }])


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Test
 - [x] Docs
 - [x] Refactor
 - [x] Build-related changes
 - [ ] Other, please describe:

### Description:

This PR updates the names of the two main methods it exposes: `validateMiddleware` and `responseValidation`. These names have been replaced by `validateRequest` and `validateResponse` for more consistency and give a better insight on what they do. 

This is a **breaking change**, so, following the [semantic versioning standard](https://docs.npmjs.com/about-semantic-versioning), version number have been increased to 2.0.0.

### Task list:

:heavy_check_mark: **Test**
- [x] Update `fake-server` example with new library method names.

:arrows_counterclockwise: **Refactor**
- [x] Rename `validateMiddleware` and `responseValidation`.

:memo: **Documentation**
- [x] Update `README` with new names.
- [x] Improve JSDoc comments in `index.js`.  

:whale: **Project configuration**
- [x] Change version number to `2.0.0`.